### PR TITLE
Add option to hide dock icon

### DIFF
--- a/visor.js
+++ b/visor.js
@@ -24,6 +24,10 @@ module.exports = class Visor {
             this.setBounds();
         }
 
+        if (this.config.hideDock) {
+            this.app.dock.hide();
+        }
+
         this.registerGlobalHotkey();
     }
 


### PR DESCRIPTION
Allow hiding the Hyper icon from the dock and the app switcher, as the
combination of both a hotkey and app switching can be disruptive and
confusing.