### PR TITLE
Disable hide for full-screen app

### DIFF
--- a/visor.js
+++ b/visor.js
@@ -58,7 +58,9 @@ module.exports = class Visor {
         }
 
         if (this.visorWindow.isFocused()) {
-            this.visorWindow.hide();
+            if (!this.visorWindow.isFullScreen()) {
+                this.visorWindow.hide();
+            }
             this.returnFocus();
         } else {
             this.setBounds();


### PR DESCRIPTION
Hiding a full-screen app in macOS results in a full-screen pane with an
empty black window.